### PR TITLE
PR #20: Implementation for issue #51

### DIFF
--- a/python_src/main.py
+++ b/python_src/main.py
@@ -35,7 +35,7 @@ def run_from_scenario(scenario_file):
     sim_factory = SimulationFactory(CrashScenario.from_json(scenario_data))
     simulation = Simulation(sim_factory=sim_factory)
     simulation.execute_scenario(timeout=60)
-    print(f'SimulationScore: {SimulationScore(simulation).calculate(debug=True)}')
+    print(f'Simulation Score: {SimulationScore(simulation).calculate(debug=True)}')
 
 
 # make sure we invoke cli

--- a/python_src/main.py
+++ b/python_src/main.py
@@ -1,7 +1,7 @@
 import click
 import json
 from visualization import VehicleTrajectoryVisualizer
-from models import SimulationFactory, Simulation, SimulationScore, categorize_report
+from models import SimulationFactory, Simulation, SimulationScore
 from models.ac3rp import CrashScenario
 
 
@@ -34,18 +34,8 @@ def run_from_scenario(scenario_file):
         scenario_data = json.load(file)
     sim_factory = SimulationFactory(CrashScenario.from_json(scenario_data))
     simulation = Simulation(sim_factory=sim_factory)
-    simulation.execute_scenario(60)
-
-    data_targets = simulation.targets
-    data_outputs = simulation.get_data_outputs()
-    result = (0, 0, 0)
-    for vehicle in data_targets:
-        data_target = data_targets[vehicle]
-        creator = categorize_report(data_target)
-        data_output = data_outputs[vehicle]
-        result = tuple(map(lambda x, y: x + y, result, creator.match(data_output, data_target)))
-    print(f'Result: {result}')
-    print(f'SimulationScore: {SimulationScore(simulation_tuple=result).calculate()}')
+    simulation.execute_scenario(timeout=60)
+    print(f'SimulationScore: {SimulationScore(simulation).calculate(debug=True)}')
 
 
 # make sure we invoke cli

--- a/python_src/main.py
+++ b/python_src/main.py
@@ -1,7 +1,7 @@
 import click
 import json
 from visualization import VehicleTrajectoryVisualizer
-from models import SimulationFactory, Simulation, categorize_report
+from models import SimulationFactory, Simulation, SimulationScore, categorize_report
 from models.ac3rp import CrashScenario
 
 
@@ -38,15 +38,14 @@ def run_from_scenario(scenario_file):
 
     data_targets = simulation.targets
     data_outputs = simulation.get_data_outputs()
-    print(data_targets)
-    print(data_outputs)
-    target = (0, 0, 0)
+    result = (0, 0, 0)
     for vehicle in data_targets:
         data_target = data_targets[vehicle]
         creator = categorize_report(data_target)
         data_output = data_outputs[vehicle]
-        target = tuple(map(lambda x, y: x + y, target, creator.match(data_output, data_target)))
-    print(f'Result: {target}')
+        result = tuple(map(lambda x, y: x + y, result, creator.match(data_output, data_target)))
+    print(f'Result: {result}')
+    print(f'SimulationScore: {SimulationScore(simulation_tuple=result).calculate()}')
 
 
 # make sure we invoke cli

--- a/python_src/models/__init__.py
+++ b/python_src/models/__init__.py
@@ -6,3 +6,4 @@ from .police_report import categorize_report
 from .ac3r import CrashScenario
 from .simulation_factory import SimulationFactory
 from .simulation import Simulation
+from .simulation_score import SimulationScore

--- a/python_src/models/simulation_score.py
+++ b/python_src/models/simulation_score.py
@@ -21,7 +21,7 @@ class SimulationScore:
         self.simulation = simulation
 
     @staticmethod
-    def _formula(alpha: float, beta: float, tpl: Tuple[int, int, int] = (0, 0, 0)):
+    def formula(alpha: float, beta: float, tpl: Tuple[int, int, int] = (0, 0, 0)):
         return 1 + (alpha * tpl[MATCHING_CRASH_INDEX]) + (beta * tpl[MATCHING_NONCRASH_INDEX])
 
     def calculate(self, debug: bool = False):
@@ -41,4 +41,4 @@ class SimulationScore:
         if debug is True:
             print(result)
 
-        return self._formula(self.alpha, self.beta, result)
+        return self.formula(self.alpha, self.beta, result)

--- a/python_src/models/simulation_score.py
+++ b/python_src/models/simulation_score.py
@@ -1,3 +1,6 @@
+import models
+from typing import Tuple
+
 MATCHING_CRASH_INDEX = 0
 MATCHING_NONCRASH_INDEX = 1
 
@@ -10,12 +13,32 @@ class SimulationScore:
     Args:
         alpha (float): weight for number of matching crashed parts
         beta (float): weight for number of matching non-crashed parts
-        simulation_tuple (tuple): (match crash, match non-crash, maximum conditions)
+        simulation (models.Simulation): a running simulation of specific scenario
     """
-    def __init__(self, alpha: float = 0.2, beta: float = 0.1, simulation_tuple: tuple[int, int, int] = (0, 0, 0)):
+    def __init__(self, simulation: models.Simulation, alpha: float = 0.2, beta: float = 0.1):
         self.alpha = alpha
         self.beta = beta
-        self.simulation_tuple = simulation_tuple
+        self.simulation = simulation
 
-    def calculate(self):
-        return 1 + (self.alpha * self.simulation_tuple[MATCHING_CRASH_INDEX]) + (self.beta * self.simulation_tuple[MATCHING_NONCRASH_INDEX])
+    @staticmethod
+    def _formula(alpha: float, beta: float, tpl: Tuple[int, int, int] = (0, 0, 0)):
+        return 1 + (alpha * tpl[MATCHING_CRASH_INDEX]) + (beta * tpl[MATCHING_NONCRASH_INDEX])
+
+    def calculate(self, debug: bool = False):
+        data_targets = self.simulation.targets
+        data_outputs = self.simulation.get_data_outputs()
+        if debug is True:
+            print("Log SimulationScore.calculate(): ")
+            print(data_targets)
+            print(data_outputs)
+
+        result = (0, 0, 0)
+        for vehicle in data_targets:
+            data_target = data_targets[vehicle]
+            creator = models.categorize_report(data_target)
+            data_output = data_outputs[vehicle]
+            result = tuple(map(lambda x, y: x + y, result, creator.match(data_output, data_target)))
+        if debug is True:
+            print(result)
+
+        return self._formula(self.alpha, self.beta, result)

--- a/python_src/models/simulation_score.py
+++ b/python_src/models/simulation_score.py
@@ -1,0 +1,21 @@
+MATCHING_CRASH_INDEX = 0
+MATCHING_NONCRASH_INDEX = 1
+
+
+class SimulationScore:
+    """
+    The SimulationScore class calculates the desired score to each simulation scenario. The score can be used
+    in the Fitness function to measure the effectiveness of the algorithm
+
+    Args:
+        alpha (float): weight for number of matching crashed parts
+        beta (float): weight for number of matching non-crashed parts
+        simulation_tuple (tuple): (match crash, match non-crash, maximum conditions)
+    """
+    def __init__(self, alpha: float = 0.2, beta: float = 0.1, simulation_tuple: tuple[int, int, int] = (0, 0, 0)):
+        self.alpha = alpha
+        self.beta = beta
+        self.simulation_tuple = simulation_tuple
+
+    def calculate(self):
+        return 1 + (self.alpha * self.simulation_tuple[MATCHING_CRASH_INDEX]) + (self.beta * self.simulation_tuple[MATCHING_NONCRASH_INDEX])

--- a/python_src/tests/runner.py
+++ b/python_src/tests/runner.py
@@ -2,6 +2,7 @@ import unittest
 import test_police_report
 from test_script_factory import ScriptVisualizationTest
 from test_road_profiler import RoadProfilerTest
+from test_simulation_score import TestSimScore
 
 
 if __name__ == "__main__":
@@ -10,4 +11,5 @@ if __name__ == "__main__":
     suite = test_police_report.load_tests(loader)
     suite.addTests(loader.loadTestsFromTestCase(ScriptVisualizationTest))
     suite.addTests(loader.loadTestsFromTestCase(RoadProfilerTest))
+    suite.addTests(loader.loadTestsFromTestCase(TestSimScore))
     runner.run(suite)

--- a/python_src/tests/test_simulation_score.py
+++ b/python_src/tests/test_simulation_score.py
@@ -1,0 +1,18 @@
+import unittest
+from models import SimulationScore
+
+
+class TestSimScore(unittest.TestCase):
+    def test_formula_for_Case06(self):
+        expected = 1.7
+        target = SimulationScore.formula(alpha=0.2, beta=0.1, tpl=(2, 3, 5))
+        self.assertEqual(expected, target)
+
+    def test_formula_for_sample_multi_reports(self):
+        expected = 1.9
+        target = SimulationScore.formula(alpha=0.2, beta=0.1, tpl=(2, 5, 11))
+        self.assertEqual(expected, target)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
We have a SimulationScore that receives such parameters:
- A running simulation of a specific scenario.
- Alpha and Beta as weights. `α` is bigger than `β`, starting with 0.2 and 0.1.

There is a formula using the number of matching crashed and match non-crashed elements `tuple(match crash, match non-crash, maximum conditions)` to calculate fitness score for a simulation:
> 1 + (α * match_crash) + (β * match_non-crash)